### PR TITLE
Widget tweaks

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -587,7 +587,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                 iconColor = onPrimaryContainerColor,
                 isPlaying = isPlaying,
                 iconSize = 36.dp,
-                cornerRadius = 30.dp
+                cornerRadius = bgCornerRadius
             )
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -77,19 +77,24 @@ private object AlbumArtBitmapCache {
 class PixelPlayGlanceWidget : GlanceAppWidget() {
 
     companion object {
-        private val ONE_BY_ONE_SIZE = DpSize(60.dp, 60.dp)
-        private val ONE_BY_TWO_SIZE = DpSize(60.dp, 120.dp)
-        private val TWO_BY_ONE_SIZE = DpSize(120.dp, 60.dp)
-        private val TWO_BY_TWO_SIZE = DpSize(120.dp, 120.dp)
-        private val THREE_BY_ONE_SIZE = DpSize(180.dp, 60.dp)
-        private val THREE_BY_TWO_SIZE = DpSize(180.dp, 120.dp)
-        private val THREE_BY_THREE_SIZE = DpSize(180.dp, 180.dp)
-        private val FOUR_BY_TWO_SIZE = DpSize(240.dp, 120.dp)
-        private val FOUR_BY_THREE_SIZE = DpSize(240.dp, 180.dp)
-        private val FOUR_BY_FOUR_SIZE = DpSize(240.dp, 240.dp)
-        private val FIVE_BY_THREE_SIZE = DpSize(300.dp, 180.dp)
-        private val FIVE_BY_FOUR_SIZE = DpSize(300.dp, 240.dp)
-        private val FIVE_BY_FIVE_SIZE = DpSize(300.dp, 300.dp)
+        // Calculated using the formula from the Android developer documentation
+        // to provide more accurate breakpoints for responsive layouts.
+        // Widths are based on the smaller portrait mode cell size.
+        // Heights are based on the smaller landscape mode cell size.
+
+        private val ONE_BY_ONE_SIZE = DpSize(57.dp, 51.dp)
+        private val ONE_BY_TWO_SIZE = DpSize(57.dp, 117.dp)
+        private val TWO_BY_ONE_SIZE = DpSize(130.dp, 51.dp)
+        private val TWO_BY_TWO_SIZE = DpSize(130.dp, 117.dp)
+        private val THREE_BY_ONE_SIZE = DpSize(203.dp, 51.dp)
+        private val THREE_BY_TWO_SIZE = DpSize(203.dp, 117.dp)
+        private val THREE_BY_THREE_SIZE = DpSize(203.dp, 184.dp)
+        private val FOUR_BY_TWO_SIZE = DpSize(276.dp, 117.dp)
+        private val FOUR_BY_THREE_SIZE = DpSize(276.dp, 184.dp)
+        private val FOUR_BY_FOUR_SIZE = DpSize(276.dp, 250.dp)
+        private val FIVE_BY_THREE_SIZE = DpSize(349.dp, 184.dp)
+        private val FIVE_BY_FOUR_SIZE = DpSize(349.dp, 250.dp)
+        private val FIVE_BY_FIVE_SIZE = DpSize(349.dp, 316.dp)
     }
 
     override val sizeMode = SizeMode.Responsive(

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -248,7 +248,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                     context = context
                 )
 
-                size.width >= ONE_BY_TWO_SIZE.width && size.height >= ONE_BY_TWO_SIZE.height -> GabeWidgetLayout(
+                size.width >= ONE_BY_TWO_SIZE.width && size.width < 59.dp && size.height >= ONE_BY_TWO_SIZE.height -> GabeWidgetLayout(
                     modifier = baseModifier,
                     backgroundColor = actualBackgroundColor,
                     bgCornerRadius = 360.dp,
@@ -528,21 +528,25 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         val onPrimaryContainerColor = GlanceTheme.colors.onPrimaryContainer
 
         Box(
-            modifier = modifier.background(backgroundColor).cornerRadius(bgCornerRadius)
-                .padding(10.dp)
+            modifier = modifier // Apply the base modifier for click handling and sizing
+                .background(backgroundColor).cornerRadius(bgCornerRadius),
+            contentAlignment = Alignment.Center
         ) {
             Column(
-                modifier = GlanceModifier.fillMaxSize(),
+                modifier = GlanceModifier.padding(10.dp).fillMaxSize()
+                    .cornerRadius(bgCornerRadius), // Padding applied to the content area
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalAlignment = Alignment.Vertical.CenterVertically
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                AlbumArtImageGlance(
-                    modifier = GlanceModifier.defaultWeight().fillMaxWidth().height(44.dp),
-                    bitmapData = albumArtBitmapData,
-                    context = context,
-                    cornerRadius = 64.dp
-                )
-                Spacer(GlanceModifier.height(8.dp))
+                Column(modifier = GlanceModifier.fillMaxSize().cornerRadius(bgCornerRadius)) {
+                    AlbumArtImageGlance(
+                        modifier = GlanceModifier.height(44.dp)
+                            .fillMaxWidth(), // Fills the width of the padded Column
+                        bitmapData = albumArtBitmapData, context = context, cornerRadius = 64.dp
+                    )
+                    Spacer(GlanceModifier.height(8.dp))
+
+
                 Column(
                     modifier = GlanceModifier.defaultWeight().cornerRadius(bgCornerRadius)
                 ) {
@@ -571,6 +575,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                         cornerRadius = 10.dp
                     )
                 }
+            }
             }
         }
     }
@@ -621,8 +626,9 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalAlignment = Alignment.Horizontal.CenterHorizontally
             ) {
+                Spacer(GlanceModifier.width(4.dp))
                 AlbumArtImageGlance(
-                    modifier = GlanceModifier.defaultWeight().padding(vertical = 6.dp),
+                    modifier = GlanceModifier.defaultWeight().padding(vertical = 10.dp),
                     bitmapData = albumArtBitmapData,
                     context = context,
                     cornerRadius = 64.dp
@@ -657,8 +663,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         val playButtonCornerRadius = if (isPlaying) 12.dp else 60.dp
 
         Box(
-            modifier = modifier.background(backgroundColor).cornerRadius(bgCornerRadius)
-                .padding(12.dp)
+            modifier = modifier.background(backgroundColor).padding(12.dp)
         ) {
             Column(
                 modifier = GlanceModifier.fillMaxSize(),

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -83,7 +83,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         // Heights are based on the smaller landscape mode cell size.
 
         private val ONE_BY_ONE_SIZE = DpSize(57.dp, 51.dp)
-        private val ONE_BY_TWO_SIZE = DpSize(57.dp, 117.dp)
+        private val ONE_BY_TWO_SIZE = DpSize(57.dp, 154.dp)
         private val TWO_BY_ONE_SIZE = DpSize(130.dp, 51.dp)
         private val TWO_BY_TWO_SIZE = DpSize(130.dp, 117.dp)
         private val THREE_BY_ONE_SIZE = DpSize(203.dp, 51.dp)
@@ -92,7 +92,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         private val FOUR_BY_TWO_SIZE = DpSize(276.dp, 117.dp)
         private val FOUR_BY_THREE_SIZE = DpSize(276.dp, 184.dp)
         private val FOUR_BY_FOUR_SIZE = DpSize(276.dp, 250.dp)
-        private val FIVE_BY_THREE_SIZE = DpSize(349.dp, 184.dp)
+        private val FIVE_BY_THREE_SIZE = DpSize(349.dp, 200.dp)
         private val FIVE_BY_FOUR_SIZE = DpSize(349.dp, 250.dp)
         private val FIVE_BY_FIVE_SIZE = DpSize(349.dp, 316.dp)
     }
@@ -584,7 +584,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
 
         Box(
             modifier = modifier.background(backgroundColor).cornerRadius(bgCornerRadius)
-                .padding(8.dp), contentAlignment = Alignment.Center
+                .padding(10.dp), contentAlignment = Alignment.Center
         ) {
             PlayPauseButtonGlance(
                 modifier = GlanceModifier.fillMaxSize(),

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -218,7 +218,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                     bgCornerRadius = 28.dp
                 )
 
-                FOUR_BY_TWO_SIZE -> ThinWidgetLayout(
+                FOUR_BY_TWO_SIZE -> ThinWidgetLayoutPadded(
                     modifier = baseModifier,
                     backgroundColor = actualBackgroundColor,
                     bgCornerRadius = 60.dp,
@@ -339,14 +339,79 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
+                    text = title, style = TextStyle(
+                        fontSize = 16.sp, fontWeight = FontWeight.Bold, color = textColor
+                    ), maxLines = 1, modifier = GlanceModifier.padding(bottom = 8.dp)
+                )
+
+                Row(
+                    modifier = GlanceModifier.defaultWeight().fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    AlbumArtImageGlance(
+                        modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
+                        bitmapData = albumArtBitmapData,
+                        context = context,
+                        cornerRadius = bgCornerRadius
+                    )
+
+                    Spacer(GlanceModifier.width(8.dp))
+
+                    PlayPauseButtonGlance(
+                        modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
+                        backgroundColor = primaryContainerColor,
+                        iconColor = onPrimaryContainerColor,
+                        isPlaying = isPlaying,
+                        iconSize = 26.dp,
+                        cornerRadius = bgCornerRadius
+                    )
+                    Spacer(GlanceModifier.width(8.dp))
+                    NextButtonGlance(
+                        modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
+                        iconColor = onSecondaryColor,
+                        iconSize = 26.dp,
+                        backgroundColor = secondaryColor,
+                        cornerRadius = bgCornerRadius
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun ThinWidgetLayoutPadded(
+        modifier: GlanceModifier,
+        backgroundColor: ColorProvider,
+        bgCornerRadius: Dp,
+        title: String,
+        artist: String,
+        albumArtBitmapData: ByteArray?,
+        isPlaying: Boolean,
+        textColor: ColorProvider,
+        context: Context
+    ) {
+        val secondaryColor = GlanceTheme.colors.secondaryContainer
+        val onSecondaryColor = GlanceTheme.colors.onSecondaryContainer
+        val primaryContainerColor = GlanceTheme.colors.primaryContainer
+        val onPrimaryContainerColor = GlanceTheme.colors.onPrimaryContainer
+
+        Box(
+            modifier = modifier.background(backgroundColor).cornerRadius(bgCornerRadius)
+                .padding(top = 12.dp, bottom = 12.dp, start = 16.dp, end = 16.dp)
+        ) {
+            Column(
+                modifier = GlanceModifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
                     text = title,
                     style = TextStyle(
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = textColor
+                        fontSize = 16.sp, fontWeight = FontWeight.Bold, color = textColor
                     ),
                     maxLines = 1,
-                    modifier = GlanceModifier.padding(bottom = 8.dp)
+                    modifier = GlanceModifier.padding(start = 12.dp, end = 10.dp, bottom = 8.dp)
                 )
 
                 Row(

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -197,7 +197,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                 THREE_BY_TWO_SIZE -> ThinWidgetLayout(
                     modifier = baseModifier,
                     backgroundColor = actualBackgroundColor,
-                    bgCornerRadius = 60.dp,
+                    bgCornerRadius = 28.dp,
                     title = title,
                     artist = artist,
                     albumArtBitmapData = albumArtBitmapData,
@@ -275,7 +275,6 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         val onSecondaryColor = GlanceTheme.colors.onSecondaryContainer
         val primaryContainerColor = GlanceTheme.colors.primaryContainer
         val onPrimaryContainerColor = GlanceTheme.colors.onPrimaryContainer
-        LocalSize.current
 
         Box(
             modifier = modifier.background(backgroundColor).cornerRadius(bgCornerRadius)
@@ -329,26 +328,24 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         val onSecondaryColor = GlanceTheme.colors.onSecondaryContainer
         val primaryContainerColor = GlanceTheme.colors.primaryContainer
         val onPrimaryContainerColor = GlanceTheme.colors.onPrimaryContainer
-        LocalSize.current
 
         Box(
             modifier = modifier.background(backgroundColor).cornerRadius(bgCornerRadius)
-                .padding(12.dp) // Padding applied to the outer box
+                .padding(12.dp)
         ) {
             Row(
                 modifier = GlanceModifier.fillMaxSize().cornerRadius(bgCornerRadius),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalAlignment = Alignment.Horizontal.CenterHorizontally
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-
                 AlbumArtImageGlance(
                     modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
                     bitmapData = albumArtBitmapData,
                     context = context,
-                    cornerRadius = bgCornerRadius
+                    cornerRadius = 10.dp
                 )
 
-                Spacer(GlanceModifier.width(8.dp)) // Changed from height(8.dp) to width(8.dp)
+                Spacer(GlanceModifier.width(8.dp))
 
                 PlayPauseButtonGlance(
                     modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
@@ -358,7 +355,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                     iconSize = 26.dp,
                     cornerRadius = 10.dp
                 )
-                Spacer(GlanceModifier.width(10.dp))
+                Spacer(GlanceModifier.width(8.dp))
                 NextButtonGlance(
                     modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
                     iconColor = onSecondaryColor,
@@ -366,7 +363,6 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                     backgroundColor = secondaryColor,
                     cornerRadius = 10.dp
                 )
-
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -83,7 +83,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         // Heights are based on the smaller landscape mode cell size.
 
         private val ONE_BY_ONE_SIZE = DpSize(57.dp, 51.dp)
-        private val ONE_BY_TWO_SIZE = DpSize(57.dp, 154.dp)
+        private val ONE_BY_TWO_SIZE = DpSize(57.dp, 117.dp)
         private val TWO_BY_ONE_SIZE = DpSize(130.dp, 51.dp)
         private val TWO_BY_TWO_SIZE = DpSize(130.dp, 117.dp)
         private val THREE_BY_ONE_SIZE = DpSize(203.dp, 51.dp)
@@ -92,7 +92,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         private val FOUR_BY_TWO_SIZE = DpSize(276.dp, 117.dp)
         private val FOUR_BY_THREE_SIZE = DpSize(276.dp, 184.dp)
         private val FOUR_BY_FOUR_SIZE = DpSize(276.dp, 250.dp)
-        private val FIVE_BY_THREE_SIZE = DpSize(349.dp, 200.dp)
+        private val FIVE_BY_THREE_SIZE = DpSize(349.dp, 184.dp)
         private val FIVE_BY_FOUR_SIZE = DpSize(349.dp, 250.dp)
         private val FIVE_BY_FIVE_SIZE = DpSize(349.dp, 316.dp)
     }
@@ -120,6 +120,8 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         provideContent {
             val playerInfo = currentState<PlayerInfo>()
             val currentSize = LocalSize.current
+
+            println("Current Size: $currentSize")
 
             Timber.tag("PixelPlayGlanceWidget")
                 .d("Providing Glance. PlayerInfo: title='${playerInfo.songTitle}', artist='${playerInfo.artistName}', isPlaying=${playerInfo.isPlaying}, hasBitmap=${playerInfo.albumArtBitmapData != null}, progress=${playerInfo.currentPositionMs}/${playerInfo.totalDurationMs}")
@@ -149,93 +151,25 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         val baseModifier =
             GlanceModifier.fillMaxSize().clickable(actionStartActivity<MainActivity>())
 
+        println(size)
         Box(
             GlanceModifier.fillMaxSize()
         ) {
-            when (size) {
-                ONE_BY_ONE_SIZE -> OneByOneWidgetLayout(
+            when {
+                size.width >= FIVE_BY_THREE_SIZE.width && size.height >= FIVE_BY_THREE_SIZE.height -> ExtraLargeWidgetLayout(
                     modifier = baseModifier,
-                    backgroundColor = actualBackgroundColor,
-                    bgCornerRadius = 100.dp,
-                    isPlaying = isPlaying
-                )
-
-                ONE_BY_TWO_SIZE -> GabeWidgetLayout(
-                    modifier = baseModifier,
-                    backgroundColor = actualBackgroundColor,
-                    bgCornerRadius = 360.dp,
+                    title = title,
+                    artist = artist,
                     albumArtBitmapData = albumArtBitmapData,
                     isPlaying = isPlaying,
-                    context = context
-                )
-
-                TWO_BY_ONE_SIZE -> SmallHorizontalWidgetLayout(
-                    modifier = baseModifier,
-                    backgroundColor = actualBackgroundColor,
-                    bgCornerRadius = 60.dp,
-                    albumArtBitmapData = albumArtBitmapData,
-                    isPlaying = isPlaying,
-                    context = context
-                )
-
-                TWO_BY_TWO_SIZE -> SmallWidgetLayout(
-                    modifier = baseModifier,
                     backgroundColor = actualBackgroundColor,
                     bgCornerRadius = 28.dp,
-                    albumArtBitmapData = albumArtBitmapData,
-                    isPlaying = isPlaying,
-                    context = context
-                )
-
-                THREE_BY_ONE_SIZE -> VeryThinWidgetLayout(
-                    modifier = baseModifier,
-                    backgroundColor = actualBackgroundColor,
-                    bgCornerRadius = 60.dp,
-                    title = title,
-                    artist = artist,
-                    albumArtBitmapData = albumArtBitmapData,
-                    isPlaying = isPlaying,
-                    textColor = onBackgroundColor,
-                    context = context
-                )
-
-                THREE_BY_TWO_SIZE -> ThinWidgetLayout(
-                    modifier = baseModifier,
-                    backgroundColor = actualBackgroundColor,
-                    bgCornerRadius = 28.dp,
-                    title = title,
-                    artist = artist,
-                    albumArtBitmapData = albumArtBitmapData,
-                    isPlaying = isPlaying,
-                    textColor = onBackgroundColor,
-                    context = context
-                )
-
-                THREE_BY_THREE_SIZE -> MediumWidgetLayout(
-                    modifier = baseModifier,
-                    title = title,
-                    artist = artist,
-                    albumArtBitmapData = albumArtBitmapData,
-                    isPlaying = isPlaying,
                     textColor = onBackgroundColor,
                     context = context,
-                    backgroundColor = actualBackgroundColor,
-                    bgCornerRadius = 28.dp
+                    queue = playerInfo.queue
                 )
 
-                FOUR_BY_TWO_SIZE -> ThinWidgetLayoutPadded(
-                    modifier = baseModifier,
-                    backgroundColor = actualBackgroundColor,
-                    bgCornerRadius = 60.dp,
-                    title = title,
-                    artist = artist,
-                    albumArtBitmapData = albumArtBitmapData,
-                    isPlaying = isPlaying,
-                    textColor = onBackgroundColor,
-                    context = context
-                )
-
-                FOUR_BY_THREE_SIZE -> LargeWidgetLayout(
+                size.width >= FOUR_BY_THREE_SIZE.width && size.height >= FOUR_BY_THREE_SIZE.height -> LargeWidgetLayout(
                     modifier = baseModifier,
                     title = title,
                     artist = artist,
@@ -248,17 +182,86 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                     context = context
                 )
 
-                else -> ExtraLargeWidgetLayout(
+                size.width >= FOUR_BY_TWO_SIZE.width && size.height >= FOUR_BY_TWO_SIZE.height -> ThinWidgetLayoutPadded(
+                    modifier = baseModifier,
+                    backgroundColor = actualBackgroundColor,
+                    bgCornerRadius = 60.dp,
+                    title = title,
+                    artist = artist,
+                    albumArtBitmapData = albumArtBitmapData,
+                    isPlaying = isPlaying,
+                    textColor = onBackgroundColor,
+                    context = context
+                )
+
+                size.width >= THREE_BY_THREE_SIZE.width && size.height >= THREE_BY_THREE_SIZE.height -> MediumWidgetLayout(
                     modifier = baseModifier,
                     title = title,
                     artist = artist,
                     albumArtBitmapData = albumArtBitmapData,
                     isPlaying = isPlaying,
-                    backgroundColor = actualBackgroundColor,
-                    bgCornerRadius = 28.dp,
                     textColor = onBackgroundColor,
                     context = context,
-                    queue = playerInfo.queue
+                    backgroundColor = actualBackgroundColor,
+                    bgCornerRadius = 28.dp
+                )
+
+                size.width >= THREE_BY_TWO_SIZE.width && size.height >= THREE_BY_TWO_SIZE.height -> ThinWidgetLayout(
+                    modifier = baseModifier,
+                    backgroundColor = actualBackgroundColor,
+                    bgCornerRadius = 28.dp,
+                    title = title,
+                    artist = artist,
+                    albumArtBitmapData = albumArtBitmapData,
+                    isPlaying = isPlaying,
+                    textColor = onBackgroundColor,
+                    context = context
+                )
+
+                size.width >= THREE_BY_ONE_SIZE.width && size.height >= THREE_BY_ONE_SIZE.height -> VeryThinWidgetLayout(
+                    modifier = baseModifier,
+                    backgroundColor = actualBackgroundColor,
+                    bgCornerRadius = 60.dp,
+                    title = title,
+                    artist = artist,
+                    albumArtBitmapData = albumArtBitmapData,
+                    isPlaying = isPlaying,
+                    textColor = onBackgroundColor,
+                    context = context
+                )
+
+                size.width >= TWO_BY_TWO_SIZE.width && size.height >= TWO_BY_TWO_SIZE.height -> SmallWidgetLayout(
+                    modifier = baseModifier,
+                    backgroundColor = actualBackgroundColor,
+                    bgCornerRadius = 28.dp,
+                    albumArtBitmapData = albumArtBitmapData,
+                    isPlaying = isPlaying,
+                    context = context
+                )
+
+                size.width >= TWO_BY_ONE_SIZE.width && size.height >= TWO_BY_ONE_SIZE.height -> SmallHorizontalWidgetLayout(
+                    modifier = baseModifier,
+                    backgroundColor = actualBackgroundColor,
+                    bgCornerRadius = 60.dp,
+                    albumArtBitmapData = albumArtBitmapData,
+                    isPlaying = isPlaying,
+                    context = context
+                )
+
+                size.width >= ONE_BY_TWO_SIZE.width && size.height >= ONE_BY_TWO_SIZE.height -> GabeWidgetLayout(
+                    modifier = baseModifier,
+                    backgroundColor = actualBackgroundColor,
+                    bgCornerRadius = 360.dp,
+                    albumArtBitmapData = albumArtBitmapData,
+                    isPlaying = isPlaying,
+                    context = context
+                )
+
+                else -> OneByOneWidgetLayout(
+                    modifier = baseModifier,
+                    backgroundColor = actualBackgroundColor,
+                    bgCornerRadius = 100.dp,
+                    isPlaying = isPlaying
                 )
             }
         }

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -329,12 +329,11 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         val onSecondaryColor = GlanceTheme.colors.onSecondaryContainer
         val primaryContainerColor = GlanceTheme.colors.primaryContainer
         val onPrimaryContainerColor = GlanceTheme.colors.onPrimaryContainer
-        val size = LocalSize.current
-        val albumArtSize = size.height - 32.dp
+        LocalSize.current
 
         Box(
             modifier = modifier.background(backgroundColor).cornerRadius(bgCornerRadius)
-                .padding(16.dp) // Padding applied to the outer box
+                .padding(12.dp) // Padding applied to the outer box
         ) {
             Row(
                 modifier = GlanceModifier.fillMaxSize().cornerRadius(bgCornerRadius),
@@ -343,29 +342,16 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
             ) {
 
                 AlbumArtImageGlance(
-                    modifier = GlanceModifier.size(albumArtSize),
+                    modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
                     bitmapData = albumArtBitmapData,
                     context = context,
                     cornerRadius = bgCornerRadius
                 )
-                Spacer(GlanceModifier.width(14.dp))
-                Column(modifier = GlanceModifier.defaultWeight()) {
-                    Text(
-                        text = title, style = TextStyle(
-                            fontSize = 16.sp, fontWeight = FontWeight.Bold, color = textColor
-                        ), maxLines = 1
-                    )
-                    if (artist.isNotEmpty() && artist != "Toca para abrir") {
-                        Text(
-                            text = artist,
-                            style = TextStyle(fontSize = 14.sp, color = textColor),
-                            maxLines = 1
-                        )
-                    }
-                }
-                Spacer(GlanceModifier.width(8.dp))
+
+                Spacer(GlanceModifier.width(8.dp)) // Changed from height(8.dp) to width(8.dp)
+
                 PlayPauseButtonGlance(
-                    modifier = GlanceModifier.defaultWeight().size(48.dp, 48.dp).fillMaxHeight(),
+                    modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
                     backgroundColor = primaryContainerColor,
                     iconColor = onPrimaryContainerColor,
                     isPlaying = isPlaying,
@@ -374,12 +360,13 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                 )
                 Spacer(GlanceModifier.width(10.dp))
                 NextButtonGlance(
-                    modifier = GlanceModifier.defaultWeight().size(48.dp, 48.dp).fillMaxHeight(),
+                    modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
                     iconColor = onSecondaryColor,
                     iconSize = 26.dp,
                     backgroundColor = secondaryColor,
                     cornerRadius = 10.dp
                 )
+
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -333,36 +333,53 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
             modifier = modifier.background(backgroundColor).cornerRadius(bgCornerRadius)
                 .padding(12.dp)
         ) {
-            Row(
-                modifier = GlanceModifier.fillMaxSize().cornerRadius(bgCornerRadius),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalAlignment = Alignment.CenterHorizontally
+            Column(
+                modifier = GlanceModifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                AlbumArtImageGlance(
-                    modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
-                    bitmapData = albumArtBitmapData,
-                    context = context,
-                    cornerRadius = 10.dp
+                Text(
+                    text = title,
+                    style = TextStyle(
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = textColor
+                    ),
+                    maxLines = 1,
+                    modifier = GlanceModifier.padding(bottom = 8.dp)
                 )
 
-                Spacer(GlanceModifier.width(8.dp))
+                Row(
+                    modifier = GlanceModifier.defaultWeight().fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    AlbumArtImageGlance(
+                        modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
+                        bitmapData = albumArtBitmapData,
+                        context = context,
+                        cornerRadius = bgCornerRadius
+                    )
 
-                PlayPauseButtonGlance(
-                    modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
-                    backgroundColor = primaryContainerColor,
-                    iconColor = onPrimaryContainerColor,
-                    isPlaying = isPlaying,
-                    iconSize = 26.dp,
-                    cornerRadius = 10.dp
-                )
-                Spacer(GlanceModifier.width(8.dp))
-                NextButtonGlance(
-                    modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
-                    iconColor = onSecondaryColor,
-                    iconSize = 26.dp,
-                    backgroundColor = secondaryColor,
-                    cornerRadius = 10.dp
-                )
+                    Spacer(GlanceModifier.width(8.dp))
+
+                    PlayPauseButtonGlance(
+                        modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
+                        backgroundColor = primaryContainerColor,
+                        iconColor = onPrimaryContainerColor,
+                        isPlaying = isPlaying,
+                        iconSize = 26.dp,
+                        cornerRadius = bgCornerRadius
+                    )
+                    Spacer(GlanceModifier.width(8.dp))
+                    NextButtonGlance(
+                        modifier = GlanceModifier.defaultWeight().fillMaxHeight(),
+                        iconColor = onSecondaryColor,
+                        iconSize = 26.dp,
+                        backgroundColor = secondaryColor,
+                        cornerRadius = bgCornerRadius
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/WidgetPreviews.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/WidgetPreviews.kt
@@ -59,91 +59,91 @@ class PixelPlayGlanceWidgetPreviewProvider : GlanceAppWidget() {
  * This sets up the correct rendering environment for Glance composables.
  */
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 60, heightDp = 60)
+@Preview(widthDp = 57, heightDp = 51)
 @Composable
 fun PixelPlayWidget_Preview_1x1() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 60, heightDp = 120)
+@Preview(widthDp = 57, heightDp = 154)
 @Composable
 fun PixelPlayWidget_Preview_1x2() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 120, heightDp = 60)
+@Preview(widthDp = 130, heightDp = 51)
 @Composable
 fun PixelPlayWidget_Preview_2x1() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 120, heightDp = 120)
+@Preview(widthDp = 130, heightDp = 117)
 @Composable
 fun PixelPlayWidget_Preview_2x2() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 180, heightDp = 60)
+@Preview(widthDp = 203, heightDp = 51)
 @Composable
 fun PixelPlayWidget_Preview_3x1() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 180, heightDp = 120)
+@Preview(widthDp = 203, heightDp = 117)
 @Composable
 fun PixelPlayWidget_Preview_3x2() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 180, heightDp = 180)
+@Preview(widthDp = 203, heightDp = 184)
 @Composable
 fun PixelPlayWidget_Preview_3x3() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 240, heightDp = 120)
+@Preview(widthDp = 276, heightDp = 117)
 @Composable
 fun PixelPlayWidget_Preview_4x2() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 240, heightDp = 180)
+@Preview(widthDp = 276, heightDp = 184)
 @Composable
 fun PixelPlayWidget_Preview_4x3() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 240, heightDp = 240)
+@Preview(widthDp = 276, heightDp = 250)
 @Composable
 fun PixelPlayWidget_Preview_4x4() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 300, heightDp = 180)
+@Preview(widthDp = 349, heightDp = 184)
 @Composable
 fun PixelPlayWidget_Preview_5x3() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 300, heightDp = 240)
+@Preview(widthDp = 349, heightDp = 250)
 @Composable
 fun PixelPlayWidget_Preview_5x4() {
     PixelPlayGlanceWidgetPreviewProvider().Content()
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 300, heightDp = 300)
+@Preview(widthDp = 349, heightDp = 316)
 @Composable
 fun PixelPlayWidget_Preview_5x5() {
     PixelPlayGlanceWidgetPreviewProvider().Content()

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/WidgetPreviews.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/WidgetPreviews.kt
@@ -129,7 +129,7 @@ fun PixelPlayWidget_Preview_4x4() {
 }
 
 @OptIn(ExperimentalGlancePreviewApi::class)
-@Preview(widthDp = 349, heightDp = 184)
+@Preview(widthDp = 349, heightDp = 220)
 @Composable
 fun PixelPlayWidget_Preview_5x3() {
     PixelPlayGlanceWidgetPreviewProvider().Content()

--- a/app/src/main/res/xml/pixelplay_glance_widget_info.xml
+++ b/app/src/main/res/xml/pixelplay_glance_widget_info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="10dp"
-    android:minHeight="10dp"
+    android:minWidth="57dp"
+    android:minHeight="51dp"
     android:targetCellWidth="4"
     android:targetCellHeight="2"
     android:updatePeriodMillis="0"


### PR DESCRIPTION
This pull request refactors the responsive layout logic for the `PixelPlayGlanceWidget` to use more accurate size breakpoints based on Android developer documentation, and updates the widget layout selection logic to use conditional checks instead of a direct mapping. Additionally, it introduces a new `ThinWidgetLayoutPadded` composable and makes several improvements to padding, alignment, and layout consistency across widget sizes.

**Responsive layout improvements:**

* Updated the size constants (`ONE_BY_ONE_SIZE`, `TWO_BY_TWO_SIZE`, etc.) in the widget companion object to use more accurate width and height values based on Android developer documentation, improving responsive behavior.
* Refactored the widget layout selection logic to use conditional checks on `size.width` and `size.height` instead of a direct mapping, allowing for more flexible and accurate widget layout rendering for different sizes. [[1]](diffhunk://#diff-81d338ef0729479755992b42bd9c7378434c7c904605818863f2da38844acdcfR154-R212) [[2]](diffhunk://#diff-81d338ef0729479755992b42bd9c7378434c7c904605818863f2da38844acdcfL197-R221) [[3]](diffhunk://#diff-81d338ef0729479755992b42bd9c7378434c7c904605818863f2da38844acdcfL209-R264)

**New and updated composables:**

* Added a new `ThinWidgetLayoutPadded` composable for improved appearance and padding in thin widget layouts, and updated layout code to use this composable where appropriate.
* Improved layout and padding in several composables (`LargeWidgetLayout`, `OneByOneWidgetLayout`, etc.), including adjustments to corner radii, spacing, and alignment for a more consistent look across widget sizes. [[1]](diffhunk://#diff-81d338ef0729479755992b42bd9c7378434c7c904605818863f2da38844acdcfL458-R549) [[2]](diffhunk://#diff-81d338ef0729479755992b42bd9c7378434c7c904605818863f2da38844acdcfL517-R603) [[3]](diffhunk://#diff-81d338ef0729479755992b42bd9c7378434c7c904605818863f2da38844acdcfR629-R631) [[4]](diffhunk://#diff-81d338ef0729479755992b42bd9c7378434c7c904605818863f2da38844acdcfL587-R666)

**Debugging and code cleanup:**

* Added `println` statements for debugging current widget size and layout selection. [[1]](diffhunk://#diff-81d338ef0729479755992b42bd9c7378434c7c904605818863f2da38844acdcfR124-R125) [[2]](diffhunk://#diff-81d338ef0729479755992b42bd9c7378434c7c904605818863f2da38844acdcfR154-R212)
* Removed unused references to `LocalSize.current` in some composables.